### PR TITLE
chore: fix Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js for use with Actions
         uses: actions/setup-node@v1.1.0
         with:
-          node-version: '12.x'
+          node-version: '12.13.1'
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Install dependencies with Yarn
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js for use with Actions
         uses: actions/setup-node@v1.1.0
         with:
-          node-version: '12.x'
+          node-version: '12.13.1'
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Install dependencies with Yarn
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js for use with Actions
         uses: actions/setup-node@v1.1.0
         with:
-          node-version: '12.x'
+          node-version: '12.13.1'
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Install dependencies with Yarn
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node.js for use with Actions
         uses: actions/setup-node@v1.1.0
         with:
-          node-version: '12.x'
+          node-version:
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Install dependencies with Yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1
         with:
           node-version: '12.13.1'
       - name: Install Yarn
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1
         with:
           node-version: '12.13.1'
       - name: Install Yarn
@@ -54,7 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1
         with:
           node-version: '12.13.1'
       - name: Install Yarn
@@ -74,7 +74,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1.1.0
+        uses: actions/setup-node@v1
         with:
           node-version:
       - name: Install Yarn


### PR DESCRIPTION
The current CI is failing because Yarn is expecting Node.js 12 but Node.js 10 is getting installed. By pinning the version from `12.x` to `12.14.1` Node.js will get installed and the CI will run properly.